### PR TITLE
implement alias for sql-functions

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -161,8 +161,8 @@ Sql.prototype.travelXORExpression = function (ast) {
   this.appendKeyword(ast.operator);
   this.travel(ast.right);
 }
-Sql.prototype.travelNull = 
-Sql.prototype.travelBoolean = 
+Sql.prototype.travelNull =
+Sql.prototype.travelBoolean =
 Sql.prototype.travelBooleanExtra = function (ast) {
   this.appendKeyword(ast.value);
 }
@@ -184,6 +184,12 @@ Sql.prototype.travelFunctionCall = function (ast) {
     }
   }
   this.append(')', true);
+  if (ast.alias) {
+    if (ast.hasAs) {
+      this.appendKeyword('as');
+    }
+    this.travel(ast.alias);
+  }
 }
 Sql.prototype.travelFunctionCallParam = function (ast) {
   if (ast.distinctOpt) {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -136,5 +136,10 @@ AND (rd.rd_numberofrooms <= (select sum(rn.reservation_numberofrooms) as count_r
   it ('restore semicolon.', function () {
     testParser('select a from b limit 2;');
   });
+
+  it ('recognoce alias for sql-function calls in stringify function.', function () {
+    testParser('SELECT COUNT(*) AS total FROM b');
+  });
+
 });
 


### PR DESCRIPTION
Function calls can have alias assigned. The parser recognizes, but the stringify function ignores.
Should be fixed with this PR. Only tested for COUNT(*) in field list.

And yes - my editor automatically did some trailing space removals.