### PR TITLE
allow [$:] as prefix and plain ? for prepared statements

### DIFF
--- a/test/main.test.js
+++ b/test/main.test.js
@@ -360,5 +360,7 @@ describe('select grammar support', function () {
     testParser('SELECT COUNT(*) AS total FROM b');
   });
 
+  it ('allow prepared statement prefix ("$" or ":") or plain ?.', function () {
+    testParser('SELECT * FROM b WHERE id=$id OR id=:id ORDER BY ?');
+  });
 });
-


### PR DESCRIPTION
This allows handling of the $-prefix (postgresql and sequelize bind), :-previx (PHP PDO and sequelize replace) and single ? (most DBS for prepared steatement.
But this PR allows this placeholder on more positions than the underlaying databases, so its for people who need preapared-statement support and know what they do. I am not shure if this should go into master. Anyway it works for me and is out for now.
By the way some trailing whitespace are stripped, so use git diff -w