### PR TITLE
Broken build due to import

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,5 +1,3 @@
-import { timingSafeEqual } from "crypto";
-
 if (!sqlParser) {
   sqlParser = {};
 }


### PR DESCRIPTION
There is currently an unused `import` statement which ends up appearing in the built parser. With the latest release of this module, this breaks my code since `import` statements aren't directly supported. In general, this could be handled by preprocessing with something like Babel, but in this case, the import wasn't actually used so I just removed it.

Would be great if another release could be made after this is merged :)`