### PR TITLE
Add additional set operations

### DIFF
--- a/src/stringify.js
+++ b/src/stringify.js
@@ -545,6 +545,22 @@ Sql.prototype.travelUnion = function (ast) {
   }
   this.travel(ast.right);
 }
+Sql.prototype.travelIntersect = function (ast) {
+  this.travel(ast.left);
+  this.appendKeyword('INTERSECT');
+  if (ast.distinctOpt) {
+    this.appendKeyword(ast.distinctOpt)
+  }
+  this.travel(ast.right);
+}
+Sql.prototype.travelExcept = function (ast) {
+  this.travel(ast.left);
+  this.appendKeyword('EXCEPT');
+  if (ast.distinctOpt) {
+    this.appendKeyword(ast.distinctOpt)
+  }
+  this.travel(ast.right);
+}
 Sql.prototype.travelSelectParenthesized = function (ast) {
   this.appendKeyword('(');
   this.travel(ast.value);

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -377,5 +377,37 @@ describe('select grammar support', function () {
     testParser('select a from dual order by a desc limit 1, 1 union distinct select a from foo order by a limit 1');
   });
 
+  it ('intersect support', function () {
+    testParser('select a from dual intersect select a from foo;');
+  });
+
+  it ('intersect Parenthesized support', function () {
+    testParser('(select a from dual) intersect (select a from foo) order by a desc limit 100, 100;');
+  });
+
+  it ('intersect all support', function () {
+    testParser('(select a from dual) intersect all (select a from foo) order by a limit 100');
+  });
+
+  it ('intersect distinct support', function () {
+    testParser('select a from dual order by a desc limit 1, 1 intersect distinct select a from foo order by a limit 1');
+  });
+
+  it ('except support', function () {
+    testParser('select a from dual except select a from foo;');
+  });
+
+  it ('except Parenthesized support', function () {
+    testParser('(select a from dual) except (select a from foo) order by a desc limit 100, 100;');
+  });
+
+  it ('except all support', function () {
+    testParser('(select a from dual) except all (select a from foo) order by a limit 100');
+  });
+
+  it ('except distinct support', function () {
+    testParser('select a from dual order by a desc limit 1, 1 except distinct select a from foo order by a limit 1');
+  });
+
 });
 


### PR DESCRIPTION
This provides a partial implementation for #18. Basically almost the same grammar is used but `INTERSECT` and `EXCEPT` are allowed as keywords in addition to `UNION`. Each of these parses into a new kind of top-level expression. This is roughly following what Postgres does since these are not all supported by MySQL.