### PR TITLE
feat: add support for quoted alias

### DIFF
--- a/src/sqlParser.jison
+++ b/src/sqlParser.jison
@@ -127,6 +127,7 @@ UNION                                                             return 'UNION'
 [a-zA-Z_\u4e00-\u9fa5][a-zA-Z0-9_\u4e00-\u9fa5]*                  return 'IDENTIFIER'
 \.                                                                return 'DOT'
 ['"][a-zA-Z_\u4e00-\u9fa5][a-zA-Z0-9_\u4e00-\u9fa5]*["']          return 'QUOTED_IDENTIFIER'
+[`].+[`]                                                          return 'QUOTED_IDENTIFIER'
 
 <<EOF>>                                                           return 'EOF'
 .                                                                 return 'INVALID'
@@ -279,6 +280,8 @@ selectExprAliasOpt
   : { $$ = {alias: null, hasAs: null} }
   | AS IDENTIFIER { $$ = {alias: $2, hasAs: true} }
   | IDENTIFIER { $$ = {alias: $1, hasAs: false} }
+  | AS QUOTED_IDENTIFIER { $$ = {alias: $2, hasAs: true} }
+  | QUOTED_IDENTIFIER { $$ = {alias: $1, hasAs: false} }
   ;
 
 string

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -387,4 +387,14 @@ describe('select grammar support', function() {
       'select a from dual order by a desc limit 1, 1 union distinct select a from foo order by a limit 1'
     );
   });
+
+  it('support quoted alias', function() {
+    testParser('select a as `A-A` from b limit 2;');
+    testParser('select a as `A#A` from b limit 2;');
+    testParser('select a as `A?A` from b limit 2;');
+    testParser('select a as `A/B` from b limit 2;');
+    testParser('select a as `A.A` from b limit 2;');
+    testParser('select a as `A|A` from b limit 2;');
+    testParser('select a as `A A` from b limit 2;');
+  });
 });


### PR DESCRIPTION
We are using this parser and we would like to be able to use quoted alias like on the tests. 
Basically, anything quoted should be safe as a quoted identifier?

Thanks.