### PR TITLE
fix: fix support for quoted alias

### DIFF
--- a/src/sqlParser.jison
+++ b/src/sqlParser.jison
@@ -126,8 +126,8 @@ UNION                                                             return 'UNION'
 
 [a-zA-Z_\u4e00-\u9fa5][a-zA-Z0-9_\u4e00-\u9fa5]*                  return 'IDENTIFIER'
 \.                                                                return 'DOT'
-['"][a-zA-Z_\u4e00-\u9fa5][a-zA-Z0-9_\u4e00-\u9fa5]*["']          return 'QUOTED_IDENTIFIER'
-([`])(?:(?=(\\?))\2.)*?\1                                         return 'QUOTED_IDENTIFIER'
+['"][a-zA-Z_\u4e00-\u9fa5][a-zA-Z0-9_\u4e00-\u9fa5]*["']          return 'IDENTIFIER'
+([`])(?:(?=(\\?))\2.)*?\1                                         return 'IDENTIFIER'
 
 <<EOF>>                                                           return 'EOF'
 .                                                                 return 'INVALID'
@@ -280,8 +280,6 @@ selectExprAliasOpt
   : { $$ = {alias: null, hasAs: null} }
   | AS IDENTIFIER { $$ = {alias: $2, hasAs: true} }
   | IDENTIFIER { $$ = {alias: $1, hasAs: false} }
-  | AS QUOTED_IDENTIFIER { $$ = {alias: $2, hasAs: true} }
-  | QUOTED_IDENTIFIER { $$ = {alias: $1, hasAs: false} }
   | AS STRING { $$ = {alias: $2, hasAs: true} }
   | STRING { $$ = {alias: $2, hasAs: false} }
   ;
@@ -328,14 +326,6 @@ identifier_list
   : identifier { $$ = { type: 'IdentifierList', value: [ $1 ] } }
   | identifier_list ',' identifier { $$ = $1; $1.value.push($3); }
   ;
-quoted_identifier
-  : QUOTED_IDENTIFIER { $$ = { type: 'Identifier', value: $1 } }
-  | quoted_identifier DOT QUOTED_IDENTIFIER { $$ = $1; $1.value += '.' + $3 }
-  ;
-quoted_identifier_list
-  : quoted_identifier { $$ = { type: 'IdentifierList', value: [ $1 ] } }
-  | quoted_identifier_list ',' quoted_identifier { $$ = $1; $1.value.push($3); }
-  ;
 case_expr_opt
   : { $$ = null }
   | expr { $$ = $1 }
@@ -361,7 +351,6 @@ simple_expr_prefix
 simple_expr
   : literal { $$ = $1 }
   | identifier { $$ = $1 }
-  | quoted_identifier { $$ = $1 }
   | function_call { $$ = $1 }
   | simple_expr_prefix { $$ = $1 }
   | '(' expr_list ')' { $$ = { type: 'SimpleExprParentheses', value: $2 } }

--- a/src/sqlParser.jison
+++ b/src/sqlParser.jison
@@ -282,8 +282,9 @@ selectExprAliasOpt
   | IDENTIFIER { $$ = {alias: $1, hasAs: false} }
   | AS QUOTED_IDENTIFIER { $$ = {alias: $2, hasAs: true} }
   | QUOTED_IDENTIFIER { $$ = {alias: $1, hasAs: false} }
+  | AS STRING { $$ = {alias: $2, hasAs: true} }
+  | STRING { $$ = {alias: $2, hasAs: false} }
   ;
-
 string
   : STRING { $$ = { type: 'String', value: $1 } }
   ;

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -3,7 +3,7 @@
 const debug = require('debug')('js-sql-parser');
 const parser = require('../');
 
-const testParser = function(sql) {
+const testParser = function (sql) {
   let firstAst = parser.parse(sql);
   debug(JSON.stringify(firstAst, null, 2));
   let firstSql = parser.stringify(firstAst);
@@ -22,24 +22,24 @@ const testParser = function(sql) {
   return secondAst;
 };
 
-describe('select grammar support', function() {
-  it('test0', function() {
+describe('select grammar support', function () {
+  it('test0', function () {
     testParser('select a from b where c > 1 group by d order by e desc;');
   });
 
-  it('test1', function() {
+  it('test1', function () {
     testParser('select distinct max_statement_time = 1.2 a ');
   });
 
-  it('test2', function() {
+  it('test2', function () {
     testParser('select all 0x1f');
   });
 
-  it('test3', function() {
+  it('test3', function () {
     testParser('select distinctrow "xx", a in (1,2)');
   });
 
-  it('test4', function() {
+  it('test4', function () {
     testParser(`
       select
         tag_basic.gender as gender,
@@ -58,17 +58,17 @@ describe('select grammar support', function() {
     `);
   });
 
-  it('test5', function() {
+  it('test5', function () {
     testParser('select function(), function(1, "sd", 0x1F)');
   });
 
-  it('test6 unicode', function() {
+  it('test6 unicode', function () {
     testParser(`
       select in中文 from tags
     `);
   });
 
-  it('test7', function() {
+  it('test7', function () {
     testParser(`
       SELECT 
         DISTINCT high_priority MAX_STATEMENT_TIME=1 STRAIGHT_JOIN SQL_SMALL_RESULT SQL_BIG_RESULT SQL_BUFFER_RESULT SQL_CACHE SQL_CALC_FOUND_ROWS fm_customer.lname AS name1,
@@ -89,7 +89,7 @@ describe('select grammar support', function() {
     `);
   });
 
-  it('test8', function() {
+  it('test8', function () {
     testParser(`
       SELECT   P1.PAYMENTNO, P1.AMOUNT,
       (P1.AMOUNT * 100) / SUM(P2.AMOUNT)
@@ -99,7 +99,7 @@ describe('select grammar support', function() {
     `);
   });
 
-  it('test9', function() {
+  it('test9', function () {
     testParser(`
         SELECT  PLAYERS.PLAYERNO, NAME,
        (SELECT   COUNT(*)
@@ -114,7 +114,7 @@ describe('select grammar support', function() {
     `);
   });
 
-  it('test10', function() {
+  it('test10', function () {
     testParser(`
       SELECT rd.*, rd.rd_numberofrooms - (
         SELECT SUM(rn.reservation_numberofrooms) AS count_reserve_room
@@ -148,11 +148,11 @@ describe('select grammar support', function() {
     `);
   });
 
-  it('test11 SELECT `LEFT`(a, 3) FROM b support.', function() {
+  it('test11 SELECT `LEFT`(a, 3) FROM b support.', function () {
     testParser('SELECT `LEFT`(a, 3) FROM b');
   });
 
-  it('test12', function() {
+  it('test12', function () {
     testParser(`
       select
           a.product_id,
@@ -202,7 +202,7 @@ describe('select grammar support', function() {
     `);
   });
 
-  it('test13', function() {
+  it('test13', function () {
     testParser(`
       SELECT
           a.*, f.ORG_NAME DEPT_NAME,
@@ -286,7 +286,7 @@ describe('select grammar support', function() {
     `);
   });
 
-  it('test14', function() {
+  it('test14', function () {
     testParser(`
       SELECT
           k.*,
@@ -345,7 +345,7 @@ describe('select grammar support', function() {
     `);
   });
 
-  it('test15', function() {
+  it('test15', function () {
     testParser(`
       SELECT   P1.PAYMENTNO, P1.AMOUNT, (P1.AMOUNT * 100) / SUM(P2.AMOUNT)
       FROM     PENALTIES AS P1, PENALTIES AS P2
@@ -354,41 +354,41 @@ describe('select grammar support', function() {
     `);
   });
 
-  it('limit support.', function() {
+  it('limit support.', function () {
     testParser('select a from b limit 2, 3');
   });
 
-  it('fix not equal.', function() {
+  it('fix not equal.', function () {
     testParser('select a from b where a <> 1 limit 2, 3');
   });
 
-  it('restore semicolon.', function() {
+  it('restore semicolon.', function () {
     testParser('select a from b limit 2;');
   });
 
-  it('recognoce alias for sql-function calls in stringify function.', function() {
+  it('recognoce alias for sql-function calls in stringify function.', function () {
     testParser('SELECT COUNT(*) AS total, a b, b as c, c/2 d, d & e an FROM b');
   });
 
-  it('union support, https://dev.mysql.com/doc/refman/8.0/en/union.html', function() {
+  it('union support, https://dev.mysql.com/doc/refman/8.0/en/union.html', function () {
     testParser('select a from dual union select a from foo;');
   });
 
-  it('union Parenthesized support, https://dev.mysql.com/doc/refman/8.0/en/union.html', function() {
+  it('union Parenthesized support, https://dev.mysql.com/doc/refman/8.0/en/union.html', function () {
     testParser('(select a from dual) union (select a from foo) order by a desc limit 100, 100;');
   });
 
-  it('union all support, https://dev.mysql.com/doc/refman/8.0/en/union.html', function() {
+  it('union all support, https://dev.mysql.com/doc/refman/8.0/en/union.html', function () {
     testParser('(select a from dual) union all (select a from foo) order by a limit 100');
   });
 
-  it('union distinct support, https://dev.mysql.com/doc/refman/8.0/en/union.html', function() {
+  it('union distinct support, https://dev.mysql.com/doc/refman/8.0/en/union.html', function () {
     testParser(
       'select a from dual order by a desc limit 1, 1 union distinct select a from foo order by a limit 1'
     );
   });
 
-  it('support quoted alias', function() {
+  it('support quoted alias', function () {
     testParser('select a as `A-A` from b limit 2;');
     testParser('select a as `A#A` from b limit 2;');
     testParser('select a as `A?A` from b limit 2;');
@@ -398,7 +398,7 @@ describe('select grammar support', function() {
     testParser('select a as `A A` from b limit 2;');
   });
 
-  it('bugfix table alias', function() {
+  it('bugfix table alias', function () {
     testParser(`
     SELECT stime, A.names, B.names FROM (
       SELECT stime, names FROM iaas_data.iaas_d3c0d0681cc1900
@@ -416,5 +416,10 @@ describe('select grammar support', function() {
     testParser('select a as `A A`, b as `B B` from z');
     testParser('select a as `A A` from z order by `A A` desc');
     testParser('select a as `A A`, b as `B B` from z group by `A A`, `B B` order by `A A` desc');
+  });
+
+  it('support double quoted alias', function () {
+    testParser('select a as "A A" from z');
+    testParser('select a as "A A" from z order by "A A" desc');
   });
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -408,7 +408,13 @@ describe('select grammar support', function() {
     `);
   });
 
-  it('bugfix table alias2', function() {
+  it('bugfix table alias2', function () {
     testParser('select a.* from a t1 join b t2 on t1.a = t2.a')
-  })
+  });
+
+  it('support quoted alias: multiple alias and orderby support', function () {
+    testParser('select a as `A A`, b as `B B` from z');
+    testParser('select a as `A A` from z order by `A A` desc');
+    testParser('select a as `A A`, b as `B B` from z group by `A A`, `B B` order by `A A` desc');
+  });
 });


### PR DESCRIPTION
Hi,
i found some issue with the support of quoted aliases.

CASE 1: multiple quoted alias
```sql
select a as `A A`, aa as `A AA` from b
```
Test result: OK
Select Item expected: 
```json
"selectItems": {
	"type": "SelectExpr",
	"value": [
		{
			"type": "Identifier",
			"value": "a",
			"alias": "`A A`",
			"hasAs": true
		},
		{
			"type": "Identifier",
			"value": "b",
			"alias": "`B B`",
			"hasAs": true
		}
	]
},
```
Received:
```json
"selectItems": {
	"type": "SelectExpr",
	"value": [
		{
			"type": "Identifier",
			"value": "a",
			"alias": "`A A`, b as `B B`",
			"hasAs": true
		}
	]
},
```
The RegEx ```[`].+[`]``` match from first backquote to last backquote. The behavior should be from one backquote to the next. Same issue for next case.

CASE 2: quoted alias in orderBy
```sql
select a as `A A` from z order by `A A` desc
```
```
     Error: Parse error on line 1:
...om z order by `A A` desc
-----------------------^
Expecting 'EOF', ';', 'UNION', ')', ',', 'FROM', got 'DESC'
```
The 'a' alias in this case is: ````A A` from z order by `A A````

--

I replace the ReqEx with this: ```([`])(?:(?=(\\?))\2.)*?\1```
And add quoted_identifier as Identifier (not as String) in expr.
The result in orderby:

```json
"orderBy": {
	"type": "OroupBy",
	"value": [
		{
			"type": "GroupByOrderByItem",
			"value": {
				"type": "Identifier",
				"value": "`A A`"
			},
			"sortOpt": "DESC"
		}
	],
	"rollUp": null
},
```


Hope my fix are correct and helpfull!
Thanks a lot for this library:)!