### PR TITLE
fix: handle comments at the end of sql without a trailing newline

### DIFF
--- a/src/sqlParser.jison
+++ b/src/sqlParser.jison
@@ -7,7 +7,7 @@
 %%
 
 [/][*](.|\n)*?[*][/]                                              /* skip comments */
-[-][-]\s.*\n                                                      /* skip sql comments */
+[-][-]\s.*\n?                                                     /* skip sql comments */
 [#]\s.*\n                                                         /* skip sql comments */
 \s+                                                               /* skip whitespace */
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -413,6 +413,6 @@ describe('select grammar support', function() {
   })
 
   it('query with comment at then end without a newline', function() {
-    testParser('select a.* from "table name"\n-- comment')
+    testParser('select a.* from a\n-- comment')
   })
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -412,7 +412,7 @@ describe('select grammar support', function() {
     testParser('select a.* from a t1 join b t2 on t1.a = t2.a')
   })
 
-  it('query with comment at then end without a newline', function() {
+  it('query with comment at the end without a trailing newline', function() {
     testParser('select a from b\n-- comment')
   })
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -411,4 +411,8 @@ describe('select grammar support', function() {
   it('bugfix table alias2', function() {
     testParser('select a.* from a t1 join b t2 on t1.a = t2.a')
   })
+
+  it('query with comment at then end without a newline', function() {
+    testParser('select a.* from "table name"\n-- comment')
+  })
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -413,6 +413,6 @@ describe('select grammar support', function() {
   })
 
   it('query with comment at then end without a newline', function() {
-    testParser('select a.* from a\n-- comment')
+    testParser('select a from b\n-- comment')
   })
 });


### PR DESCRIPTION
If the sql string ends with a comment without a trailing newline it fails. This change make it handle this case. I included a test for this as well.