### PR TITLE
feature: Added support for simple CAST

### DIFF
--- a/src/sqlParser.jison
+++ b/src/sqlParser.jison
@@ -50,6 +50,7 @@ IN                                                                return 'IN'
 SOUNDS                                                            return 'SOUNDS'
 LIKE                                                              return 'LIKE'
 ESCAPE                                                            return 'ESCAPE'
+CAST                                                              return 'CAST'
 REGEXP                                                            return 'REGEXP'
 IS                                                                return 'IS'
 UNKNOWN                                                           return 'UNKNOWN'
@@ -343,6 +344,9 @@ case_when_else
 case_when
   : CASE case_expr_opt when_then_list case_when_else END { $$ = { type: 'CaseWhen', caseExprOpt: $2, whenThenList: $3, else: $4 } }
   ;
+cast
+  : CAST '(' expr AS IDENTIFIER ')' { $$ = { type: 'Cast', expr: $3, castTo: $5 } }
+  ;
 simple_expr_prefix
   : '+' simple_expr %prec UPLUS { $$ = { type: 'Prefix', prefix: $1, value: $2 } }
   | '-' simple_expr %prec UMINUS { $$ = { type: 'Prefix', prefix: $1, value: $2 } }
@@ -361,6 +365,7 @@ simple_expr
   | EXISTS '(' selectClause ')' { $$ = { type: 'SubQuery', value: $3, hasExists: true } }
   | '{' identifier expr '}' { $$ = { type: 'IdentifierExpr', identifier: $2, value: $3 } }
   | case_when { $$ = $1 }
+  | cast { $$ = $1 }
   ;
 bit_expr
   : simple_expr { $$ = $1 }

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -225,6 +225,14 @@ Sql.prototype.travelCaseWhen = function(ast) {
   }
   this.appendKeyword('end');
 };
+Sql.prototype.travelCast = function(ast) {
+    this.appendKeyword('cast');
+    this.append('(', true, true);
+    this.travel(ast.expr);
+    this.appendKeyword('as');
+    this.append(ast.castTo);
+    this.append(')', true);
+};
 Sql.prototype.travelPrefix = function(ast) {
   this.appendKeyword(ast.prefix);
   this.travel(ast.value);

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -411,4 +411,19 @@ describe('select grammar support', function() {
   it('bugfix table alias2', function() {
     testParser('select a.* from a t1 join b t2 on t1.a = t2.a')
   })
+
+  it('CAST support issue #9', function() {
+    testParser(`select
+    concat(dsw_cluster_name,',',logic_pod_name) as event_obj,
+    concat(dsw_cluster_name,',',logic_pod_name, ' PFC STORM. 详情: ',
+    '流量突跃 ', cast(FLOW_RX_BPS_RATE100 as int), '%(RX)',
+    '; ', cast(FLOW_TX_BPS_RATE100 as int), '%(TX)',
+    '; PFC 突增 ', cast(PFC_RX_PPS_RATE*100 as int), '%(RECV)') as brief
+    from SOURCE_BASIC_EVENT_POD_FLOW_AND_PFC_TREND
+    where win_end >= '2020-05-19 21:14:12'
+    and win_end < '2020-05-20 21:14:12'
+    and PFC_RX_PPS_RATE >= 100
+    and (FLOW_RX_BPS_RATE <= -0.2 and FLOW_TX_BPS_RATE <= -0.2)
+    `)
+  })
 });


### PR DESCRIPTION
This will not handle all versions of CAST but will handle a simple case like CAST(pct*100 AS int)

The query mentioned in #9 was used as the test.

```
select
    concat(dsw_cluster_name,',',logic_pod_name) as event_obj,
    concat(dsw_cluster_name,',',logic_pod_name, ' PFC STORM. 详情: ',
    '流量突跃 ',
    cast(FLOW_RX_BPS_RATE100 as int),
    '%(RX)',
    '; ',
    cast(FLOW_TX_BPS_RATE100 as int),
    '%(TX)',
    '; PFC 突增 ',
    cast(PFC_RX_PPS_RATE*100 as int),
    '%(RECV)') as brief
from SOURCE_BASIC_EVENT_POD_FLOW_AND_PFC_TREND
where win_end >= '2020-05-19 21:14:12'
    and win_end < '2020-05-20 21:14:12'
    and PFC_RX_PPS_RATE >= 100
    and (FLOW_RX_BPS_RATE <= -0.2 and FLOW_TX_BPS_RATE <= -0.2)
```