### PR TITLE
add support for single and double quote in column alias

### DIFF
--- a/src/sqlParser.jison
+++ b/src/sqlParser.jison
@@ -282,6 +282,7 @@ selectExprAliasOpt
   | IDENTIFIER { $$ = {alias: $1, hasAs: false} }
   | AS QUOTED_IDENTIFIER { $$ = {alias: $2, hasAs: true} }
   | QUOTED_IDENTIFIER { $$ = {alias: $1, hasAs: false} }
+  | AS STRING { $$ = {alias: $2, hasAs: true} }
   ;
 
 string

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -410,5 +410,29 @@ describe('select grammar support', function() {
 
   it('bugfix table alias2', function() {
     testParser('select a.* from a t1 join b t2 on t1.a = t2.a')
-  })
+  });
+
+  it('support double quoted alias', function() {
+    testParser('select a as "A-A" from b limit 2;');
+    testParser('select a as "A#A" from b limit 2;');
+    testParser('select a as "A?A" from b limit 2;');
+    testParser('select a as "A/B" from b limit 2;');
+    testParser('select a as "A.A" from b limit 2;');
+    testParser('select a as "A|A" from b limit 2;');
+    testParser('select a as "A A" from b limit 2;');
+  });
+
+  it('support single quoted alias', function() {
+    testParser("select a as 'A-A' from b limit 2;");
+    testParser("select a as 'A#A' from b limit 2;");
+    testParser("select a as 'A?A' from b limit 2;");
+    testParser("select a as 'A/B' from b limit 2;");
+    testParser("select a as 'A.A' from b limit 2;");
+    testParser("select a as 'A|A' from b limit 2;");
+    testParser("select a as 'A A' from b limit 2;");
+  });
+
 });
+
+
+


### PR DESCRIPTION
we are using this parser but it fails when we have double or single quoted column alias.

e.g   select col1 as "col one" from tab