### PR TITLE
Enable evaluating "||"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ node_modules
 package-lock.json
 *.log
 *.swp
-dist/parser/sqlParser.js
+dist/parser/*

--- a/src/sqlParser.jison
+++ b/src/sqlParser.jison
@@ -99,6 +99,7 @@ UNION                                                             return 'UNION'
 "~"                                                               return '~'
 "!="                                                              return '!='
 "!"                                                               return '!'
+"||"                                                              return '||'
 "|"                                                               return '|'
 "&"                                                               return '&'
 "+"                                                               return '+'
@@ -365,6 +366,7 @@ simple_expr
   ;
 bit_expr
   : simple_expr { $$ = $1 }
+  | bit_expr '||' bit_expr { $$ = { type: 'BitExpression', operator: '||', left: $1, right: $3 } }
   | bit_expr '|' bit_expr { $$ = { type: 'BitExpression', operator: '|', left: $1, right: $3 } }
   | bit_expr '&' bit_expr { $$ = { type: 'BitExpression', operator: '&', left: $1, right: $3 } }
   | bit_expr '<<' bit_expr { $$ = { type: 'BitExpression', operator: '<<', left: $1, right: $3 } }


### PR DESCRIPTION
I realized that js SQL parser does not evaluate "||" as a bit expression. This is SQL standard: https://4js.com/online_documentation/fjs-fgl-manual-html/index.html#fgl-topics/c_fgl_sql_programming_099.html 