### PR TITLE
feat(): unicode extended char support for column name or alias

### DIFF
--- a/src/sqlParser.jison
+++ b/src/sqlParser.jison
@@ -11,10 +11,10 @@
 [#]\s.*\n                                                         /* skip sql comments */
 \s+                                                               /* skip whitespace */
 
-[$][{](.*?)[}]                                                    return 'PLACE_HOLDER'
-[`][a-zA-Z_\u4e00-\u9fa5][a-zA-Z0-9_\u4e00-\u9fa5]*[`]            return 'IDENTIFIER'
-[\w]+[\u4e00-\u9fa5]+[0-9a-zA-Z_\u4e00-\u9fa5]*                   return 'IDENTIFIER'
-[\u4e00-\u9fa5][0-9a-zA-Z_\u4e00-\u9fa5]*                         return 'IDENTIFIER'
+[$][{](.+?)[}]                                                    return 'PLACE_HOLDER'
+[`][a-zA-Z0-9_\u0080-\uFFFF]*[`]                                  return 'IDENTIFIER'
+[\w]+[\u0080-\uFFFF]+[0-9a-zA-Z_\u0080-\uFFFF]*                   return 'IDENTIFIER'
+[\u0080-\uFFFF][0-9a-zA-Z_\u0080-\uFFFF]*                         return 'IDENTIFIER'
 SELECT                                                            return 'SELECT'
 ALL                                                               return 'ALL'
 ANY                                                               return 'ANY'
@@ -125,7 +125,7 @@ UNION                                                             return 'UNION'
 [-]?[0-9]+(\.[0-9]+)?                                             return 'NUMERIC'
 [-]?[0-9]+(\.[0-9]+)?[eE][-][0-9]+(\.[0-9]+)?                     return 'EXPONENT_NUMERIC'
 
-[a-zA-Z_\u4e00-\u9fa5][a-zA-Z0-9_\u4e00-\u9fa5]*                  return 'IDENTIFIER'
+[a-zA-Z_\u0080-\uFFFF][a-zA-Z0-9_\u0080-\uFFFF]*                  return 'IDENTIFIER'
 \.                                                                return 'DOT'
 ["][a-zA-Z_\u4e00-\u9fa5][a-zA-Z0-9_\u4e00-\u9fa5]*["]            return 'STRING'
 ['][a-zA-Z_\u4e00-\u9fa5][a-zA-Z0-9_\u4e00-\u9fa5]*[']            return 'STRING'

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -436,4 +436,16 @@ describe('select grammar support', function () {
   it('test IDENTIFIER', function () {
     testParser('select `aa#sfs`(a) as \'A A\' from z');
   });
+
+  it('Support unicode extended char (U+0080..U+FFFF) as column name or alias', function() {
+    testParser(`select 
+      país, 
+      MAX(produção) as maior_produção, 
+      Ĉapelo,
+      Δάσος,
+      Молоко,
+      سلام,
+      かわいい
+    from table`)
+  })
 });


### PR DESCRIPTION
Currently, you cannot name (or alias) a column with certain Latin characters without using quotes, even though this is supported by [MySQL syntax](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html). In this PR, I added this.

**Parser error**:
![image](https://github.com/JavaScriptor/js-sql-parser/assets/65685842/29b4aebd-7d70-4466-89b0-ee5d654e2c47)

[MySQL syntax](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html):

```
Permitted characters in unquoted identifiers:
- ASCII: [0-9,a-z,A-Z$_] (basic Latin letters, digits 0-9, dollar, underscore)
- Extended: U+0080 .. U+FFFF
```
